### PR TITLE
AUTOENG-2852: lwes forwarding should use pool

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-* Mon Nov 30 2015 Charles Huang <huangc.cd@gmail.com> 4.0.0
+* Mon Nov 30 2015 Charles Huang <huangc.cd@gmail.com> 4.0.1
 - Enhancing mondemand_backend_lwes to use pool
 - Ehnahcing mondemand_backend_worker to pass raw data by configuration
 - mondeman_backend_lwes can now handle both raw UDP and md_event

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+* Mon Nov 30 2015 Charles Huang <huangc.cd@gmail.com> 4.0.0
+- Enhancing mondemand_backend_lwes to use pool
+- Ehnahcing mondemand_backend_worker to pass raw data by configuration
+- mondeman_backend_lwes can now handle both raw UDP and md_event
+
 * Fri Oct 23 2015 Anthony Molinaro <anthonym@alumni.caltech.edu> 4.0.0
 - breaking change for formatters, now they should return
 {ok, ResultList, NumGood, NumBad }

--- a/src/mondemand_server.app.src
+++ b/src/mondemand_server.app.src
@@ -1,7 +1,7 @@
 { application, mondemand_server,
   [
     { description,"A Server for dealing with mondemand events"},
-    { vsn,"4.0.0"},
+    { vsn,"4.0.1"},
     { modules,[]},
     { registered,[mondemand_backend_all_journaller,
                   mondemand_backend_log_file,


### PR DESCRIPTION
Adding pool support, since mondemand_backend_worker converts UDP to md_event, lwes backend now handles md_event instead of raw UDP structure. 