### PR TITLE
Add header fields to events when forwarding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+* Thu Sep 22 2016 Anthony Molinaro <anthonym@alumni.caltech.edu> 5.1.0
+- when forwarding via lwes add the sender ip/sender port and receipt time
+to the outgoing event
+
 * Wed Sep 14 2016 Anthony Molinaro <anthonym@alumni.caltech.edu> 5.0.0
 - make trace writer use pool
 - NON-BACKWARD-COMPATIBLE - removed 'stats_' prefix from worker stats as the

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+* Wed Sep 14 2016 Anthony Molinaro <anthonym@alumni.caltech.edu> 5.0.0
+- make trace writer use pool
+- NON-BACKWARD-COMPATIBLE - removed 'stats_' prefix from worker stats as the
+worker now is used for different backends.
+
 * Sat Jun 11 2016 Anthony Molinaro <anthonym@alumni.caltech.edu> 4.4.3
 - updated dependency on mondemand to 6.2.1
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
+* Sat Jun 11 2016 Anthony Molinaro <anthonym@alumni.caltech.edu> 4.4.3
+- updated dependency on mondemand to 6.2.1
+
 * Thu Jun 09 2016 Anthony Molinaro <anthonym@alumni.caltech.edu> 4.4.2
-- updated dependency on mondemand
+- updated dependency on mondemand to 6.2.0
 
 * Thu Jun 02 2016 Tim Whalen <tim.whalen@openx.com> 4.4.1
 - removed limit on number of metrics per stats message

--- a/conf/mondemand_server.config
+++ b/conf/mondemand_server.config
@@ -61,6 +61,9 @@
       },
       { mondemand_backend_trace_file,
         [
+          % necessary for pooling
+          { worker_mod, mondemand_backend_trace_file },
+
           % these fields are looked up in the trace event and added to
           % the filename separated by "-"s
           { extra_fields, [ ] },

--- a/conf/mondemand_server_dev.config
+++ b/conf/mondemand_server_dev.config
@@ -16,7 +16,8 @@
           { "MonDemand::LogMsg",   [ mondemand_backend_log_file,
                                      mondemand_backend_lwes ] },
           { "MonDemand::TraceMsg", [ mondemand_backend_trace_file ] },
-          { "MonDemand::PerfMsg",  [ mondemand_backend_performance_summarize ] }
+          { "MonDemand::PerfMsg",  [ mondemand_backend_lwes,
+                                     mondemand_backend_performance_summarize ] }
         ]
       },
 
@@ -76,8 +77,10 @@
       { mondemand_backend_lwes,
         [
           {worker_mod, mondemand_backend_lwes},
-          {lwes, {2, [{"127.0.0.1",50205},{"127.0.0.1",51215}]} },
-          {extra_context, [ {cluster, ca} ]}
+%          {lwes, {2, [{"127.0.0.1",50205},{"127.0.0.1",51215}]} },
+%          {extra_context, [{cluster, ca}]}
+          {lwes, {1, [{"127.0.0.1",11311}]}},
+          {extra_context, []}
         ]
       },
       { mondemand_backend_log_file,

--- a/conf/mondemand_server_dev.config
+++ b/conf/mondemand_server_dev.config
@@ -88,6 +88,9 @@
       },
       { mondemand_backend_trace_file,
         [
+          % necessary for pooling
+          { worker_mod, mondemand_backend_trace_file },
+
           % these fields are looked up in the trace event and added to
           % the filename separated by "-"s
           { extra_fields, [ <<"queasy.service">>, <<"queasy.type">> ] },

--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,8 @@
 {deps,
     [
       { mondemand,
-        "6.2.0",
-        {git, "git://github.com/mondemand/mondemand-erlang.git", {tag, "6.2.0"} }
+        "6.2.1",
+        {git, "git://github.com/mondemand/mondemand-erlang.git", {tag, "6.2.1"} }
       },
       { webmachine,
         "1.10.8",

--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,8 @@
 {deps,
     [
       { mondemand,
-        "6.3.0",
-        {git, "git://github.com/mondemand/mondemand-erlang.git", {tag, "6.3.0"} }
+        "6.4.1",
+        {git, "git://github.com/mondemand/mondemand-erlang.git", {tag, "6.4.1"} }
       },
       { webmachine,
         "1.10.8",

--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,8 @@
 {deps,
     [
       { mondemand,
-        "6.2.1",
-        {git, "git://github.com/mondemand/mondemand-erlang.git", {tag, "6.2.1"} }
+        "6.3.0",
+        {git, "git://github.com/mondemand/mondemand-erlang.git", {tag, "6.3.0"} }
       },
       { webmachine,
         "1.10.8",

--- a/src/mondemand_backend_lwes_global.erl
+++ b/src/mondemand_backend_lwes_global.erl
@@ -102,10 +102,17 @@ connect (State) ->
 
 send (State = #state { channels = ChannelsIn,
                        extra_context = ExtraContext },
-      {udp,_,_,_,Event} )
+      {udp, _, SenderIp, SenderPort, Event} )
       when ExtraContext =:= []; ExtraContext =:= undefined ->
 
-  ChannelsOut = lwes:emit (ChannelsIn, Event),
+  ChannelsOut =
+    lwes:emit (ChannelsIn,
+               [ Event,
+                 lwes_event:header_fields_to_iolist (
+                   mondemand_util:millis_since_epoch(),
+                   SenderIp,
+                   SenderPort)
+               ] ),
   { ok, State#state { channels = ChannelsOut } };
 
 send (State = #state { channels = ChannelsIn,
@@ -113,12 +120,22 @@ send (State = #state { channels = ChannelsIn,
       Event = #md_event {} )
       when ExtraContext =:= []; ExtraContext =:= undefined ->
 
-  ChannelsOut = lwes:emit (ChannelsIn, mondemand_event:to_lwes(Event)),
+  ChannelsOut =
+    lwes:emit (ChannelsIn,
+               [ lwes_event:to_binary (mondemand_event:to_lwes(Event)),
+                 lwes_event:header_fields_to_iolist (
+                   mondemand_event:receipt_time (Event),
+                   mondemand_event:sender_ip (Event),
+                   mondemand_event:sender_port (Event)
+                 )
+               ]
+              ),
   { ok, State#state { channels = ChannelsOut } };
 
 send (State = #state { channels = ChannelsIn,
                        extra_context = ExtraContext},
       Data ) ->
+
   case mondemand_event:peek_type_from_udp (Data) of
     undefined ->
       error_logger:error_msg ("Bad event ~p",[Data]),
@@ -126,23 +143,20 @@ send (State = #state { channels = ChannelsIn,
     stats_msg ->
       Event = mondemand_event:from_udp (Data),
       StatsMsg = mondemand_event:msg (Event),
-      Context = mondemand_statsmsg:context (StatsMsg),
-      ProgId = mondemand_statsmsg:prog_id (StatsMsg),
 
       % for the moment filter out anything not an aggregate
       % or not from the mondemand-server
       ShouldSend =
-        case lists:keyfind (<<"stat">>, 1, Context) of
-          {_,_} ->
-            true;
-          false ->
-            ProgId =:= <<"mondemand_server">>
+        case mondemand_statsmsg:context_value (StatsMsg, <<"stat">>) =:= undefined of
+          true ->
+            mondemand_statsmsg:prog_id (StatsMsg) =:= <<"mondemand_server">>;
+          _ ->
+            true
         end,
 
-      NewEvent =
-        case ShouldSend of
-          true ->
-            % split stats msgs with many metrics into multiple lwes events
+      case ShouldSend of
+        true ->
+          NewEvent =
             mondemand_event:to_lwes (
               mondemand_event:set_msg (Event,
                 mondemand_statsmsg:add_contexts (
@@ -150,24 +164,41 @@ send (State = #state { channels = ChannelsIn,
                   ExtraContext
                 )
               )
-            );
-          false ->
-            undefined
-        end,
-
-      % only send if we have an event to send
-      case NewEvent of
-        undefined ->
+            ),
+          ChannelsOut =
+           lwes:emit (ChannelsIn,
+                      [ lwes_event:to_binary (NewEvent),
+                        lwes_event:header_fields_to_iolist (
+                          mondemand_event:receipt_time (Event),
+                          mondemand_event:sender_ip (Event),
+                          mondemand_event:sender_port (Event)
+                        )
+                      ]
+                     ),
+          {ok, State#state { channels = ChannelsOut } };
+        false ->
           mondemand_server_stats:increment_backend (?MODULE, events_filtered),
-          {ok, State};
-        _ ->
-          {ok, State#state { channels = lwes:emit (ChannelsIn, NewEvent) } }
+          {ok, State}
       end;
     _ ->
-      LwesEvent = case Data of
-        #md_event {} -> mondemand_event:to_lwes(Data);
-        {udp,_,_,_,Packet} -> Packet
-      end,
+      LwesEvent =
+        case Data of
+          #md_event {} ->
+            [ lwes_event:to_binary (mondemand_event:to_lwes(Data)),
+              lwes_event:header_fields_to_iolist (
+                mondemand_event:receipt_time (Data),
+                mondemand_event:sender_ip (Data),
+                mondemand_event:sender_port (Data)
+              )
+            ];
+          {udp,_,SenderIp,SenderPort,Packet} ->
+            [ Packet,
+              lwes_event:header_fields_to_iolist (
+                mondemand_util:millis_since_epoch(),
+                SenderIp,
+                SenderPort)
+            ]
+        end,
       {ok, State#state { channels = lwes:emit (ChannelsIn, LwesEvent) } }
   end.
 

--- a/src/mondemand_server.app.src
+++ b/src/mondemand_server.app.src
@@ -1,7 +1,7 @@
 { application, mondemand_server,
   [
     { description,"A Server for dealing with mondemand events"},
-    { vsn,"4.4.2"},
+    { vsn,"4.4.3"},
     { modules,[]},
     { registered,[mondemand_backend_all_journaller,
                   mondemand_backend_log_file,

--- a/src/mondemand_server.app.src
+++ b/src/mondemand_server.app.src
@@ -1,7 +1,7 @@
 { application, mondemand_server,
   [
     { description,"A Server for dealing with mondemand events"},
-    { vsn,"5.0.0"},
+    { vsn,"5.1.0"},
     { modules,[]},
     { registered,[mondemand_backend_all_journaller,
                   mondemand_backend_log_file,

--- a/src/mondemand_server.app.src
+++ b/src/mondemand_server.app.src
@@ -1,7 +1,7 @@
 { application, mondemand_server,
   [
     { description,"A Server for dealing with mondemand events"},
-    { vsn,"4.4.3"},
+    { vsn,"5.0.0"},
     { modules,[]},
     { registered,[mondemand_backend_all_journaller,
                   mondemand_backend_log_file,

--- a/src/mondemand_server_app.erl
+++ b/src/mondemand_server_app.erl
@@ -12,8 +12,8 @@
 %% API functions
 %%====================================================================
 start () ->
-  Apps = lists:append ( [ [ sasl, lwes, mondemand, crypto, gproc,
-                            afunix, inets, asn1, public_key,
+  Apps = lists:append ( [ [ sasl, lwes, inets, mondemand, crypto, gproc,
+                            afunix, asn1, public_key,
                             ssl, xmerl, compiler, syntax_tools, mochiweb,
                             webmachine ],
                           mondemand_server_config:applications_to_start(),


### PR DESCRIPTION
This should have probably been on a feature branch, but I confused myself, anyway, this appends header fields to events when forwarding, so that the originating ip will be tracked.